### PR TITLE
Single precision normalization

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -2,42 +2,43 @@ CXX=icpc
 #SOURCE=main.cpp sparse/sparse_layer.cpp sparse/sparse_model.cpp sparse/layer.cpp sparse/dense_layer.cpp autoencoder/compressed_batch.cpp autoencoder/autoencoder.cpp
 INCLUDES := -I${EIGEN_DIR} -I${JSON_DIR} -I./ #-Isparse/ -Inormalization/ -Iautoencoder/ -Iutils/
 BUILD_DIR := ./build
-OBJS := $(BUILD_DIR)/sparse_layer.o $(BUILD_DIR)/sparse_layer.o $(BUILD_DIR)/dense_layer.o  $(BUILD_DIR)/layer.o $(BUILD_DIR)/sparse_model.o $(BUILD_DIR)/compressed_batch.o $(BUILD_DIR)/autoencoder.o $(BUILD_DIR)/compression_base.o $(BUILD_DIR)/batch_preparer.o  $(BUILD_DIR)/autoencoder_interface_c.o  ${BUILD_DIR}/autoencoder_debug.o
+OBJS := $(BUILD_DIR)/layer.o $(BUILD_DIR)/sparse_layer.o $(BUILD_DIR)/dense_layer.o  $(BUILD_DIR)/sparse_model.o $(BUILD_DIR)/compressed_batch.o $(BUILD_DIR)/autoencoder.o $(BUILD_DIR)/compression_base.o $(BUILD_DIR)/batch_preparer.o  $(BUILD_DIR)/autoencoder_interface_c.o  ${BUILD_DIR}/autoencoder_debug.o
+CXX_FLAGS := -xCORE-AVX512 -qopt-zmm-usage=high -O3 -g -mkl
 
 all: $(BUILD_DIR)/libautoencoder_c.so test
 
+$(BUILD_DIR)/layer.o: sparse/layer.cpp
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@ -march=native ${CXX_FLAGS}
+
 $(BUILD_DIR)/sparse_layer.o: sparse/sparse_layer.cpp
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@ -march=native -O3 
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@ -march=native ${CXX_FLAGS} 
 
 $(BUILD_DIR)/sparse_model.o: sparse/sparse_model.cpp
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@ -march=native -O3 
-
-$(BUILD_DIR)/layer.o: sparse/layer.cpp
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@ -march=native -O3
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@ -march=native ${CXX_FLAGS} 
 
 $(BUILD_DIR)/dense_layer.o: sparse/dense_layer.cpp
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native -O3
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native ${CXX_FLAGS}
 
 $(BUILD_DIR)/compressed_batch.o: batch_preparation/compressed_batch.cpp
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native -O3
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native ${CXX_FLAGS}
 
 $(BUILD_DIR)/batch_preparer.o: batch_preparation/batch_preparer.cpp 
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native -O3 
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native ${CXX_FLAGS} 
 
 $(BUILD_DIR)/compression_base.o: autoencoder/compression_base.cpp 
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native -O3 
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native ${CXX_FLAGS} 
 
 $(BUILD_DIR)/autoencoder.o: autoencoder/autoencoder.cpp 
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native -O3 
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native ${CXX_FLAGS} 
 
 $(BUILD_DIR)/autoencoder_debug.o: autoencoder/autoencoder_debug.cpp 
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native -O3 
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native ${CXX_FLAGS} 
 
 $(BUILD_DIR)/autoencoder_interface_c.o: autoencoder/autoencoder_interface_c.cpp 
-	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native -O3 
+	$(CXX) ${INCLUDES}  -c -fPIC $^ -o $@  -march=native ${CXX_FLAGS} 
 
 $(BUILD_DIR)/libautoencoder_c.so: $(OBJS)
-	$(CXX) ${INCLUDES}  -shared -o $@ $^ -march=native -O3 -lpthread 
+	$(CXX) ${INCLUDES}  -shared -o $@ $^ -march=native ${CXX_FLAGS} -lpthread 
 
 test: main.cpp $(BUILD_DIR)/libautoencoder_c.so
-	mpicc ${INCLUDES} $^ -o $@ -march=native -O3 -L./build -lautoencoder_c -qopenmp
+	mpicc ${INCLUDES} $^ -o $@ -march=native ${CXX_FLAGS} -L./build -lautoencoder_c -qopenmp

--- a/cpp/autoencoder/autoencoder.cpp
+++ b/cpp/autoencoder/autoencoder.cpp
@@ -50,7 +50,7 @@ namespace sparse_nn {
     // directly store last batch if it is not the correct size since
     // compressing in time requires fixed batch size
     if (currBatchSize != batchSize_) {
-      batchStorage.data = batchDataMatrix_.cast<float>();
+      batchStorage.data = batchDataMatrix_;
       return;
     }
 
@@ -60,16 +60,10 @@ namespace sparse_nn {
       batchStorage.ranges = divideAndReturnRanges(batchDataMatrix_);,
              "[COMPRESS] normalization"
     );
-    if (mpirank_ == 0) {
-      std::cout << "[DEBUG] " << batchDataMatrix_.rows() << std::endl;
-    }
-    // Eigen::MatrixXf temp;
-    // TIME_CODE(
-    //   temp = batchDataMatrix_.cast<float>();, "[COMPRESS] cast to float"
-    // );
+
 		// do compression
 		TIME_CODE(
-      batchStorage.data = encoder_.run(batchDataMatrix_.cast<float>());, "[COMPRESS] compression");
+      batchStorage.data = encoder_.run(batchDataMatrix_);, "[COMPRESS] compression");
     //verbosePrinting(batchStorage);
 	}
 	
@@ -80,7 +74,7 @@ namespace sparse_nn {
 		CompressedBatch<Eigen::MatrixXf>& batchStorage = getBatchStorage(latestTimestep, latestTimestep);
     //std::cout << "requested timestep " << latestTimestep << std::endl;
     if (batchStorage.getEndingTimestep() - batchStorage.getStartingTimestep() + 1 < batchSize_) {
-      batchDataMatrix_ = batchStorage.data.cast<double>();
+      batchDataMatrix_ = batchStorage.data;
     } else {
       Eigen::MatrixXf decompressedBatch;
       TIME_CODE(decompressedBatch = decoder_.run(batchStorage.data);, "[DECOMPRESS] decompression");
@@ -105,7 +99,7 @@ namespace sparse_nn {
     if (debugMode_ && mpirank_ == 0) {
       Eigen::MatrixXf decodedMat = decoder_.run(batchStorage.data);
       //Eigen::MatrixXd unnormalizedMat = unnormalize(decodedMat, batchStorage.mins, batchStorage.ranges);
-      double errorNorm = (decodedMat - batchDataMatrix_.cast<float>()).norm();
+      double errorNorm = (decodedMat - batchDataMatrix_).norm();
       double batchNorm = batchDataMatrix_.norm();
       if (batchNorm > 1e-13){
         double relError = errorNorm / batchNorm;

--- a/cpp/autoencoder/autoencoder_debug.cpp
+++ b/cpp/autoencoder/autoencoder_debug.cpp
@@ -31,7 +31,7 @@ namespace sparse_nn {
 			writeDataToFile();
 		}
 		
-		CompressedBatch<Eigen::MatrixXd>& batchStorage = getBatchStorage(startingTimestep, startingTimestep + currBatchSize - 1);
+		CompressedBatch<Eigen::MatrixXf>& batchStorage = getBatchStorage(startingTimestep, startingTimestep + currBatchSize - 1);
 		batchStorage.data = batchDataMatrix_;
 		return;
 	}
@@ -44,7 +44,7 @@ namespace sparse_nn {
 			std::cout << "[DECOMPRESS] Fetching timestep " << latestTimestep << std::endl;
 		}
     
-		CompressedBatch<Eigen::MatrixXd>& batchStorage = getBatchStorage(latestTimestep, latestTimestep);
+		CompressedBatch<Eigen::MatrixXf>& batchStorage = getBatchStorage(latestTimestep, latestTimestep);
 		batchDataMatrix_ = batchStorage.data;
     if (batchDataMatrix_.rows() == 0 || batchDataMatrix_.cols() == 0) {
       std::cout << "rank " << mpirank_ << " stored data has 0 shape at timestep " << latestTimestep << std::endl;
@@ -59,7 +59,7 @@ namespace sparse_nn {
 		return {batchStorage.getStartingTimestep(), batchStorage.getEndingTimestep()};
 	}
 
-	CompressedBatch<Eigen::MatrixXd>& AutoencoderDebug::getBatchStorage(const int startingTimestep, const int endingTimestep) {
+	CompressedBatch<Eigen::MatrixXf>& AutoencoderDebug::getBatchStorage(const int startingTimestep, const int endingTimestep) {
 		// this function as written is pretty brittle as handling for batches that cross
 		// muliple CompressedBatch objects is not detected or supported
 		for (auto& batch : compressedStates_) {

--- a/cpp/autoencoder/autoencoder_debug.h
+++ b/cpp/autoencoder/autoencoder_debug.h
@@ -30,8 +30,8 @@ namespace sparse_nn {
     double writeProbability_;
     int fullDimension_; // input dimension to autoencoder
 
-		std::vector<CompressedBatch<Eigen::MatrixXd>> compressedStates_;
-		CompressedBatch<Eigen::MatrixXd>& getBatchStorage(const int startingTimestep, const int endingTimestep);
+		std::vector<CompressedBatch<Eigen::MatrixXf>> compressedStates_;
+		CompressedBatch<Eigen::MatrixXf>& getBatchStorage(const int startingTimestep, const int endingTimestep);
 	};
 
 

--- a/cpp/autoencoder/compression_base.h
+++ b/cpp/autoencoder/compression_base.h
@@ -28,7 +28,7 @@ namespace sparse_nn {
 	protected:
     std::string encoderPath_;
     std::string decoderPath_;
-    Eigen::MatrixXd batchDataMatrix_;
+    Eigen::MatrixXf batchDataMatrix_;
 		
 		bool debugMode_ = false;
 		bool shouldWrite_ = false;

--- a/cpp/batch_preparation/batch_preparer.cpp
+++ b/cpp/batch_preparation/batch_preparer.cpp
@@ -187,12 +187,10 @@ namespace sparse_nn {
       // compute min and range
       //float *currMin = mins.data() + row;
       //float *currMax = ranges.data() + row;
-      float currMin; 
-      float currMax;
+      double currMin; 
+      double currMax;
 
       if (currBatchSize == nTimestepsPerBatch_) {
-        //*currMin = static_cast<float>(1e30); // really big number
-        //*currMax = static_cast<float>(-1e30); // really negative number
         currMin = 1e30;
         currMax = -1e30;
         for (int i = 0; i < nTimestepsPerBatch_ * nRkStages_; ++i) {
@@ -205,7 +203,7 @@ namespace sparse_nn {
           }
         }
         // convert max to range of data
-        currMax = currMax - currMin < 1e-7 ? 1e-7 : currMax - currMin;
+        currMax = currMax - currMin < 1e-16 ? 1e-16 : currMax - currMin;
     
       } else {
         //std::cout << "batch / matrix mismatch: " << currBatchSize << " vs " << nTimestepsPerBatch_ << std::endl; 

--- a/cpp/batch_preparation/batch_preparer.cpp
+++ b/cpp/batch_preparation/batch_preparer.cpp
@@ -7,7 +7,7 @@
 namespace sparse_nn {
   SpaceBatchPreparer::SpaceBatchPreparer() {} 
   
-	void SpaceBatchPreparer::copyVectorToMatrix(Eigen::MatrixXd& mat, const std::vector<Timestep>& dataBuffer) {		
+	void SpaceBatchPreparer::copyVectorToMatrix(Eigen::MatrixXf& mat, const std::vector<Timestep>& dataBuffer) {		
     int nStates = dataBuffer.at(0).size();
 		int totalStatesToStore = dataBuffer.size() * nStates;
     int dataSize = dataBuffer.at(0).at(0).size();
@@ -19,14 +19,14 @@ namespace sparse_nn {
 		for (const auto& fullState : dataBuffer) {
       for(const auto& currState : fullState) {
         for (int i = 0; i < currState.size(); ++i) {
-          mat(currRow, i) = currState.at(i);
+          mat(currRow, i) = static_cast<float>(currState.at(i));
         }
         ++currRow;
 			}
 		}
 	}
 	
-	void SpaceBatchPreparer::copyMatrixToVector(const Eigen::MatrixXd& mat, std::vector<Timestep>& dataBuffer) {
+	void SpaceBatchPreparer::copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) {
     int nStates = dataBuffer.at(0).size();
     assert((nStates > 0, "dataBuffer does not have all states allocated"));
     assert((mat.rows() / nStates <= dataBuffer.size(), "dataBuffer does not have enough timesteps allocated"));
@@ -35,7 +35,7 @@ namespace sparse_nn {
 			int timestepIndex = i / nStates;
       int stateIndex = i % nStates;
 			for (int j = 0; j < mat.cols(); ++j) {
-				dataBuffer.at(timestepIndex).at(stateIndex).at(j) = mat(i, j);
+				dataBuffer.at(timestepIndex).at(stateIndex).at(j) = static_cast<double>(mat(i, j));
 			}
 		}
 	}
@@ -46,7 +46,7 @@ namespace sparse_nn {
     nDofsPerElement_(nDofsPerElement), nTimestepsPerBatch_(nTimestepsPerBatch),
     nStates_(nStates), nRkStages_(nRkStages) {}
   
-	void TimeBatchPreparer::copyVectorToMatrix(Eigen::MatrixXd& mat, const std::vector<Timestep>& dataBuffer) {
+	void TimeBatchPreparer::copyVectorToMatrix(Eigen::MatrixXf& mat, const std::vector<Timestep>& dataBuffer) {
     assert((nTimestepsPerBatch_ == dataBuffer.size(), "dataBuffer does not match nTimestepsPerBatch"));
 
     int nLocalElements = dataBuffer.at(0).at(0).size() / nDofsPerElement_;
@@ -73,7 +73,7 @@ namespace sparse_nn {
               if (row >= mat.rows() || colStart >= mat.cols() || row < 0 || colStart < 0) {
                 std::cout << "attempting to write (" << row  << ", " << colStart << ") from array of size (" << mat.rows() << ", " << mat.cols() << ")" << std::endl;
               }
-              mat(row, colStart + i) = timestep.at(state + nStates_ * rk).at(elementOffset + i);
+              mat(row, colStart + i) = static_cast<float>(timestep.at(state + nStates_ * rk).at(elementOffset + i));
             }
           }
           colStart += nDofsPerElement_;
@@ -83,7 +83,7 @@ namespace sparse_nn {
     }
 	}
 	
-	void TimeBatchPreparer::copyMatrixToVector(const Eigen::MatrixXd& mat, std::vector<Timestep>& dataBuffer) {
+	void TimeBatchPreparer::copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) {
     int nLocalElements = dataBuffer.at(0).at(0).size() / nDofsPerElement_;
     int t = 0;
     for (auto& timestep : dataBuffer) {
@@ -98,7 +98,7 @@ namespace sparse_nn {
             }
             int elementOffset = element * nDofsPerElement_;
             for (int i = 0; i < nDofsPerElement_; ++i) {
-              timestep.at(state + nStates_ * rk).at(elementOffset + i) = mat(row, colStart + i);
+              timestep.at(state + nStates_ * rk).at(elementOffset + i) = static_cast<double>(mat(row, colStart + i));
             }
           }
           colStart += nDofsPerElement_;
@@ -136,7 +136,7 @@ namespace sparse_nn {
 
 
 
-  void TimeBatchPreparer::copyVectorToMatrix(Eigen::MatrixXd& mat, const double *dataBuffer, int nLocalElements) {
+  void TimeBatchPreparer::copyVectorToMatrix(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements) {
     if (mapCompressionToPde_ == nullptr) {
       createMapping(nLocalElements);
     }
@@ -147,7 +147,7 @@ namespace sparse_nn {
         int storageOffset = mapCompressionToPde_[row * nTimestepsPerBatch_ * nRkStages_ + i];
         int colOffset = nDofsPerElement_ * i;
         for (int j = 0; j < nDofsPerElement_; ++j) {
-          mat(row, colOffset + j) = dataBuffer[storageOffset + j];
+          mat(row, colOffset + j) = static_cast<float>(dataBuffer[storageOffset + j]);
         }
       }
     }
@@ -155,13 +155,13 @@ namespace sparse_nn {
 
 	}
 	
-	void TimeBatchPreparer::copyMatrixToVector(const Eigen::MatrixXd& mat, double *dataBuffer, int nLocalElements) {
+	void TimeBatchPreparer::copyMatrixToVector(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements) {
     for (int row = 0; row < mat.rows(); ++row) {
       for (int i = 0; i < nTimestepsPerBatch_ * nRkStages_; ++i) {
         int storageOffset = mapCompressionToPde_[row * nTimestepsPerBatch_ * nRkStages_ + i];
         int colOffset = nDofsPerElement_ * i;
         for (int j = 0; j < nDofsPerElement_; ++j) {
-          dataBuffer[storageOffset + j] = mat(row, colOffset + j);
+          dataBuffer[storageOffset + j] = static_cast<double>(mat(row, colOffset + j));
         }
       }
     }

--- a/cpp/batch_preparation/batch_preparer.h
+++ b/cpp/batch_preparation/batch_preparer.h
@@ -10,28 +10,28 @@ namespace sparse_nn {
   class BatchPreparer {
   public:
     BatchPreparer() = default;
-    virtual void copyVectorToMatrix(Eigen::MatrixXd& mat, const std::vector<Timestep>& dataBuffer) = 0;
-    virtual void copyMatrixToVector(const Eigen::MatrixXd& mat, std::vector<Timestep>& dataBuffer) = 0;
-    virtual void copyVectorToMatrix(Eigen::MatrixXd& mat, const double *dataBuffer, int nLocalElements) = 0;
-    virtual void copyMatrixToVector(const Eigen::MatrixXd& mat, double *dataBuffer, int nLocalElements) = 0;
+    virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const std::vector<Timestep>& dataBuffer) = 0;
+    virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) = 0;
+    virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements) = 0;
+    virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements) = 0;
   };
 
   class SpaceBatchPreparer : public BatchPreparer {
   public:
     SpaceBatchPreparer();
-    virtual void copyVectorToMatrix(Eigen::MatrixXd& mat, const std::vector<Timestep>& dataBuffer) override;
-    virtual void copyMatrixToVector(const Eigen::MatrixXd& mat, std::vector<Timestep>& dataBuffer) override;    
-    virtual void copyVectorToMatrix(Eigen::MatrixXd& mat, const double *dataBuffer, int nLocalElements) override {};
-    virtual void copyMatrixToVector(const Eigen::MatrixXd& mat, double *dataBuffer, int nLocalElements) override {};
+    virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const std::vector<Timestep>& dataBuffer) override;
+    virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) override;    
+    virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements) override {};
+    virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements) override {};
   };
 
   class TimeBatchPreparer : public BatchPreparer {
   public:
     TimeBatchPreparer(int nDofsPerElement,  int nTimestepsPerBatch, int nStates, int nRkStages);
-    virtual void copyVectorToMatrix(Eigen::MatrixXd& mat, const std::vector<Timestep>& dataBuffer) override;
-    virtual void copyMatrixToVector(const Eigen::MatrixXd& mat, std::vector<Timestep>& dataBuffer) override;
-    virtual void copyVectorToMatrix(Eigen::MatrixXd& mat, const double *dataBuffer, int nLocalElements) override;
-    virtual void copyMatrixToVector(const Eigen::MatrixXd& mat, double *dataBuffer, int nLocalElements) override;
+    virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const std::vector<Timestep>& dataBuffer) override;
+    virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) override;
+    virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements) override;
+    virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements) override;
 
   private:
     int nDofsPerElement_;

--- a/cpp/batch_preparation/batch_preparer.h
+++ b/cpp/batch_preparation/batch_preparer.h
@@ -14,6 +14,10 @@ namespace sparse_nn {
     virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) = 0;
     virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements) = 0;
     virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements) = 0;
+    virtual void copyVectorToMatrixWithNormalization(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements, 
+                                                     Eigen::VectorXf& mins, Eigen::VectorXf& ranges, int currBatchSize) = 0;
+    virtual void copyMatrixToVectorWithUnnormalization(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements, 
+                                                       const Eigen::VectorXf& mins, const Eigen::VectorXf& ranges) = 0;
   };
 
   class SpaceBatchPreparer : public BatchPreparer {
@@ -23,6 +27,10 @@ namespace sparse_nn {
     virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) override;    
     virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements) override {};
     virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements) override {};
+    virtual void copyVectorToMatrixWithNormalization(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements, 
+                                                     Eigen::VectorXf& mins, Eigen::VectorXf& ranges, int currBatchSize) override {};
+    virtual void copyMatrixToVectorWithUnnormalization(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements, 
+                                                       const Eigen::VectorXf& mins, const Eigen::VectorXf& ranges) override {};
   };
 
   class TimeBatchPreparer : public BatchPreparer {
@@ -32,6 +40,10 @@ namespace sparse_nn {
     virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, std::vector<Timestep>& dataBuffer) override;
     virtual void copyVectorToMatrix(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements) override;
     virtual void copyMatrixToVector(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements) override;
+    virtual void copyVectorToMatrixWithNormalization(Eigen::MatrixXf& mat, const double *dataBuffer, int nLocalElements, 
+                                                     Eigen::VectorXf& mins, Eigen::VectorXf& ranges, int currBatchSize) override;
+    virtual void copyMatrixToVectorWithUnnormalization(const Eigen::MatrixXf& mat, double *dataBuffer, int nLocalElements, 
+                                                       const Eigen::VectorXf& mins, const Eigen::VectorXf& ranges) override;
 
   private:
     int nDofsPerElement_;

--- a/cpp/batch_preparation/compressed_batch.h
+++ b/cpp/batch_preparation/compressed_batch.h
@@ -13,8 +13,8 @@ namespace sparse_nn {
 		int getStartingTimestep() const;
 		int getEndingTimestep() const;
 		
-		Eigen::VectorXd mins;
-		Eigen::VectorXd ranges;
+		Eigen::VectorXf mins;
+		Eigen::VectorXf ranges;
 		T data;
 		
 	private:

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -40,7 +40,7 @@ void timeBatchPreparation() {
   }
 
   auto prep = sparse_nn::TimeBatchPreparer(nDofsPerElement, nTimesteps, nStates, nRkStages);
-  Eigen::MatrixXd mat;
+  Eigen::MatrixXf mat;
 
   sparse_nn::Timer copyToMatrixTimer("Copy to matrix");
   copyToMatrixTimer.start();

--- a/cpp/normalization/normalization.h
+++ b/cpp/normalization/normalization.h
@@ -11,26 +11,26 @@
 
 namespace sparse_nn {
 	// not constants because we are modifying mat within function
-	inline Eigen::VectorXd subtractAndReturnMins(Eigen::MatrixXd& mat) {
-		Eigen::VectorXd mins = mat.rowwise().minCoeff();
+	inline Eigen::VectorXf subtractAndReturnMins(Eigen::MatrixXf& mat) {
+		Eigen::VectorXf mins = mat.rowwise().minCoeff();
 		mat.colwise() -= mins;
 
 		return mins;
 	}
 
-	inline Eigen::VectorXd divideAndReturnRanges(Eigen::MatrixXd& mat) {
+	inline Eigen::VectorXf divideAndReturnRanges(Eigen::MatrixXf& mat) {
 		// keep max and unary separate operations
 		// it turns out to be much faster for some reason
-		Eigen::VectorXd maxs = mat.rowwise().maxCoeff();
-    maxs.noalias() = maxs.unaryExpr([](double x){ return x < 1e-13 ? 1e-13 : x; });
+		Eigen::VectorXf maxs = mat.rowwise().maxCoeff();
+    maxs.noalias() = maxs.unaryExpr([](float x){ return x < 1e-7 ? (float)1e-7 : x; });
 		mat.array().colwise() /= maxs.array();
 		
 		return maxs;
 	}
 	
-	inline Eigen::MatrixXd unnormalize(const Eigen::MatrixXf& mat, const Eigen::VectorXd& mins,
-									   const Eigen::VectorXd& ranges) {
-		Eigen::MatrixXd matD = (mat.cast<double>().array().colwise() * ranges.array()).colwise() + mins.array();
+	inline Eigen::MatrixXf unnormalize(const Eigen::MatrixXf& mat, const Eigen::VectorXf& mins,
+									   const Eigen::VectorXf& ranges) {
+		Eigen::MatrixXf matD = (mat.array().colwise() * ranges.array()).colwise() + mins.array();
 		return matD;
 	}
 } // namespace sparse_nn

--- a/cpp/normalization/normalization.h
+++ b/cpp/normalization/normalization.h
@@ -12,18 +12,43 @@
 namespace sparse_nn {
 	// not constants because we are modifying mat within function
 	inline Eigen::VectorXf subtractAndReturnMins(Eigen::MatrixXf& mat) {
+    Timer computeMinsTimer = Timer("Compute mins");
+    computeMinsTimer.start();
 		Eigen::VectorXf mins = mat.rowwise().minCoeff();
+    computeMinsTimer.stop();
+    
+    Timer subtractMinsTimer = Timer("Subtract mins");
+    subtractMinsTimer.start();
 		mat.colwise() -= mins;
+    subtractMinsTimer.stop();
 
+    computeMinsTimer.print();
+    subtractMinsTimer.print();
 		return mins;
 	}
 
 	inline Eigen::VectorXf divideAndReturnRanges(Eigen::MatrixXf& mat) {
 		// keep max and unary separate operations
 		// it turns out to be much faster for some reason
+    Timer computeMaxTimer = Timer("Compute max");
+    Timer truncateTimer = Timer("Truncate to 1e-7");
+    Timer divideTimer = Timer("Divide by range");
+
+    computeMaxTimer.start();
 		Eigen::VectorXf maxs = mat.rowwise().maxCoeff();
+    computeMaxTimer.stop();
+
+    truncateTimer.start();
     maxs.noalias() = maxs.unaryExpr([](float x){ return x < 1e-7 ? (float)1e-7 : x; });
+    truncateTimer.stop();
+
+    divideTimer.start();
 		mat.array().colwise() /= maxs.array();
+    divideTimer.stop();
+
+    computeMaxTimer.print();
+    truncateTimer.print();
+    divideTimer.print();
 		
 		return maxs;
 	}


### PR DESCRIPTION
Refactored normalization into copyVectorToMatrix and copyMatrixToVector. This greatly improved the total speed of copying and normalization. Previously, copying took ~20ms and normalization took ~20ms. Combined, normalization and copying takes ~22ms. This roughly correspond to peak memory bandwidth on Frontera.